### PR TITLE
Any reason for not including these input formats?

### DIFF
--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -46,7 +46,7 @@ class Pandoc
         "epub",
         "haddock",
         "html",
-        "json*",
+        "json",
         "latex",
         "markdown",
         "markdown_github",

--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -40,19 +40,28 @@ class Pandoc
      * @var array
      */
     private $inputFormats = array(
-        "native",
-        "json",
+        "commonmark",
+        "docbook",
+        "docx",
+        "epub",
+        "haddock",
+        "html",
+        "json*",
+        "latex",
         "markdown",
-        "markdown_strict",
-        "markdown_phpextra",
         "markdown_github",
         "markdown_mmd",
-        "rst",
+        "markdown_phpextra",
+        "markdown_strict",
         "mediawiki",
-        "docbook",
+        "native",
+        "odt",
+        "opml",
+        "org",
+        "rst",
+        "t2t",
         "textile",
-        "html",
-        "latex"
+        "twiki"
     );
 
     /**


### PR DESCRIPTION
Thanks for you nice work! I tried to use the Pandoc wrapper for converting from odt (stored in a variable) and found that it was not included as an input format. When added, it works fine, I use it now on odt that is saved as a BLOB in database.

I added the formats from pandoc --help into the file. Perhaps I am missing a good reason to avoid some of them, or could this be merged?