### PR TITLE
add docx as a valid input format

### DIFF
--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -50,6 +50,7 @@ class Pandoc
         "rst",
         "mediawiki",
         "docbook",
+        "docx",
         "textile",
         "html",
         "latex"


### PR DESCRIPTION
docx claims to be a valid input and output on the pandoc website, be cool to have it supported int he white list