### PR TITLE
Add timeout parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "name": "chinapedia/pandoc-php",
+    "description": "chinapedia/pandoc-php",
+    "type": "library",
     "license": "MIT",
-    "autoload": {
-        "psr-0": {
-            "Pandoc": "src"
+    "authors": [
+        {
+            "name": "liruqi",
+            "email": "liruqi@gmail.com"
         }
-    }
+    ],
+    "require": {}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,9 @@
             "email": "liruqi@gmail.com"
         }
     ],
-    "require": {}
+    "autoload": {
+        "psr-4": {
+            "Pandoc": "src/"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ryakad/pandoc-php",
+    "name": "chinapedia/pandoc-php",
     "license": "MIT",
     "autoload": {
         "psr-0": {

--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -167,7 +167,8 @@ class Pandoc
         file_put_contents($this->tmpFile, $content);
 
         $command = sprintf(
-            '%s --from=%s --to=%s %s',
+            '%s --log=$s/pandoc.log --from=%s --to=%s %s',
+            $this->tmpDir,
             $this->executable,
             $from,
             $to,

--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -192,7 +192,7 @@ class Pandoc
      *
      * @return string The returned content
      */
-    public function runWith($content, $options)
+    public function runWith($content, $options, $timeout = 0)
     {
         $commandOptions = array();
 
@@ -212,48 +212,49 @@ class Pandoc
         );
 
         foreach ($options as $key => $value) {
-            if ($key == 'to' && in_array($value, $extFilesFormat)) {
-                $commandOptions[] = '-s -S -o '.$this->tmpFile.'.'.$value;
-                $format = $value;
-                continue;
-            } else if ($key == 'to' && in_array($value, $extFilesHtmlSlide)) {
-                $commandOptions[] = '-s -t '.$value.' -o '.$this->tmpFile.'.html';
-                $format = 'html';
-                continue;
-            } else if ($key == 'to' && $value == 'epub3') {
-                $commandOptions[] = '-S -o '.$this->tmpFile.'.epub';
-                $format = 'epub';
-                continue;
-            } else if ($key == 'to' && $value == 'beamer') {
-                $commandOptions[] = '-s -t beamer -o '.$this->tmpFile.'.pdf';
-                $format = 'pdf';
-                continue;
-            } else if ($key == 'to' && $value == 'latex') {
-                $commandOptions[] = '-s -o '.$this->tmpFile.'.tex';
-                $format = 'tex';
-                continue;
-            } else if ($key == 'to' && $value == 'rst') {
-                $commandOptions[] = '-s -t rst --toc -o '.$this->tmpFile.'.text';
-                $format = 'text';
-                continue;
-            } else if ($key == 'to' && $value == 'rtf') {
-                $commandOptions[] = '-s -o '.$this->tmpFile.'.'.$value;
-                $format = $value;
-                continue;
-            } else if ($key == 'to' && $value == 'docbook') {
-                $commandOptions[] = '-s -S -t docbook -o '.$this->tmpFile.'.db';
-                $format = 'db';
-                continue;
-            } else if ($key == 'to' && $value == 'context') {
-                $commandOptions[] = '-s -t context -o '.$this->tmpFile.'.tex';
-                $format = 'tex';
-                continue;
-            } else if ($key == 'to' && $value == 'asciidoc') {
-                $commandOptions[] = '-s -S -t asciidoc -o '.$this->tmpFile.'.txt';
-                $format = 'txt';
-                continue;
+            if ($key == 'to') {
+                if (in_array($value, $extFilesFormat)) {
+                    $commandOptions[] = '-s -S -o '.$this->tmpFile.'.'.$value;
+                    $format = $value;
+                    continue;
+                } else if (in_array($value, $extFilesHtmlSlide)) {
+                    $commandOptions[] = '-s -t '.$value.' -o '.$this->tmpFile.'.html';
+                    $format = 'html';
+                    continue;
+                } else if ($value == 'epub3') {
+                    $commandOptions[] = '-S -o '.$this->tmpFile.'.epub';
+                    $format = 'epub';
+                    continue;
+                } else if ($value == 'beamer') {
+                    $commandOptions[] = '-s -t beamer -o '.$this->tmpFile.'.pdf';
+                    $format = 'pdf';
+                    continue;
+                } else if ($value == 'latex') {
+                    $commandOptions[] = '-s -o '.$this->tmpFile.'.tex';
+                    $format = 'tex';
+                    continue;
+                } else if ($value == 'rst') {
+                    $commandOptions[] = '-s -t rst --toc -o '.$this->tmpFile.'.text';
+                    $format = 'text';
+                    continue;
+                } else if ($value == 'rtf') {
+                    $commandOptions[] = '-s -o '.$this->tmpFile.'.'.$value;
+                    $format = $value;
+                    continue;
+                } else if ($value == 'docbook') {
+                    $commandOptions[] = '-s -S -t docbook -o '.$this->tmpFile.'.db';
+                    $format = 'db';
+                    continue;
+                } else if ($value == 'context') {
+                    $commandOptions[] = '-s -t context -o '.$this->tmpFile.'.tex';
+                    $format = 'tex';
+                    continue;
+                } else if ($value == 'asciidoc') {
+                    $commandOptions[] = '-s -S -t asciidoc -o '.$this->tmpFile.'.txt';
+                    $format = 'txt';
+                    continue;
+                }
             }
-
 
             if (null === $value) {
                 $commandOptions[] = "--$key";
@@ -265,14 +266,14 @@ class Pandoc
 
         file_put_contents($this->tmpFile, $content);
         chmod($this->tmpFile, 0777);
-
+        $timeout = floatval($timeout);
+        $exe = $timeout > 0 ? "timeout $timeout {$this->executable}" : $this->executable;
         $command = sprintf(
             "%s %s %s",
-            $this->executable,
+            $exe,
             implode(' ', $commandOptions),
             $this->tmpFile
         );
-
 
         exec(escapeshellcmd($command), $output, $returnval);
         if($returnval === 0)

--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -267,7 +267,8 @@ class Pandoc
         file_put_contents($this->tmpFile, $content);
         chmod($this->tmpFile, 0777);
         $timeout = floatval($timeout);
-        $exe = $timeout > 0 ? "timeout $timeout {$this->executable}" : $this->executable;
+        $ktimeout = $timeout * 2;
+        $exe = $timeout > 0 ? "timeout -k {$ktimeout}s {$timeout}s {$this->executable}" : $this->executable;
         $command = sprintf(
             "%s %s %s",
             $exe,

--- a/src/Pandoc/Pandoc.php
+++ b/src/Pandoc/Pandoc.php
@@ -262,6 +262,13 @@ class Pandoc
                 continue;
             }
 
+            if (is_array($value)) {
+                foreach($value as $k => $v) {
+                    $commandOptions[] = "--$key=$v";
+                }
+                continue;
+            }
+
             $commandOptions[] = "--$key=$value";
         }
 


### PR DESCRIPTION
From https://pandoc.org/MANUAL.html#a-note-on-security

> Pandoc’s parsers can exhibit pathological performance on some corner cases. It is wise to put any pandoc operations under a timeout, to avoid DOS attacks that exploit these issues. If you are using the pandoc executable, you can add the command line options +RTS -M512M -RTS (for example) to limit the heap size to 512MB.